### PR TITLE
Fixes with typing resource state and Geography protocol.

### DIFF
--- a/docs/source/user_guide/tutorials/simpy_compare.rst
+++ b/docs/source/user_guide/tutorials/simpy_compare.rst
@@ -250,7 +250,7 @@ Also note that we aren't setting up the comms receive task yet. That's later.
     class Cashier(UP.Actor):
         ...
         # Messages store for when we do comms
-        messages: UP.SelfMonitoringStore = UP.ResourceState(
+        messages = UP.ResourceState[UP.SelfMonitoringStore](
             default=UP.SelfMonitoringStore,
         )
 

--- a/src/upstage/base.py
+++ b/src/upstage/base.py
@@ -58,6 +58,14 @@ class EarthProtocol(Protocol):
     ) -> list[tuple[float, float, float]]:
         """Get ECEF coordinates from lat lon alt."""
 
+    def geo_linspace(
+        self,
+        start: tuple[float, float],
+        end: tuple[float, float],
+        num_segments: int,
+    ) -> list[tuple[float, float]]:
+        """Get evenly spaced coordinates between lat/lon pairs."""
+
 
 INTERSECTION_LOCATION_CALLABLE = Callable[
     [

--- a/src/upstage/communications/comms.py
+++ b/src/upstage/communications/comms.py
@@ -59,7 +59,7 @@ class CommsManager(UpstageBase):
 
     Example:
         >>> class Talker(UP.Actor):
-        >>>     comms = UP.ResourceState(default=SIM.Store)
+        >>>     comms = UP.ResourceState[SIM.Store](default=SIM.Store)
         >>>
         >>> talker1 = Talker(name='MacReady')
         >>> talker2 = Talker(name='Childs')

--- a/src/upstage/data_types.py
+++ b/src/upstage/data_types.py
@@ -348,6 +348,15 @@ class GeodeticLocation(Location):
         """
         return (self.lat, self.lon, self.alt)
 
+    def latlon(self) -> tuple[float, float]:
+        """Return a tuple of just lat/lon as degrees.
+
+        Returns:
+            tuple[float, float]: Latitude and longitude in degrees.
+        """
+        s = self.to_degrees()
+        return (s.lat, s.lon)
+
     def to_radians(self) -> "GeodeticLocation":
         """Convert to radians, if already in radians, return self.
 

--- a/src/upstage/state_sharing.py
+++ b/src/upstage/state_sharing.py
@@ -10,7 +10,7 @@ from upstage.states import ActiveState
 from upstage.task import Task
 
 
-class SharedLinearChangingState(ActiveState):
+class SharedLinearChangingState(ActiveState[float]):
     """A state whose value changes linearly over time.
 
     Allows for multiple users of the state, keyed on actor and task.

--- a/src/upstage/states.py
+++ b/src/upstage/states.py
@@ -331,7 +331,7 @@ class ActiveState(State, Generic[ST]):
         return False
 
 
-class LinearChangingState(ActiveState[ST], Generic[ST]):
+class LinearChangingState(ActiveState[float]):
     """A state whose value changes linearly over time.
 
     When activating:
@@ -783,7 +783,7 @@ class GeodeticLocationChangingState(ActiveState[GeodeticLocation]):
         return super().deactivate(instance, task)
 
 
-T = TypeVar("T", Store, Container)
+T = TypeVar("T", bound=Store | Container)
 
 
 class ResourceState(State, Generic[T]):
@@ -807,8 +807,8 @@ class ResourceState(State, Generic[T]):
 
     Example:
         >>> class Warehouse(Actor):
-        >>>     shelf = ResourceState(default=Store)
-        >>>     bucket = ResourceState(
+        >>>     shelf = ResourceState[Store](default=Store)
+        >>>     bucket = ResourceState[Container](
         >>>         default=Container,
         >>>         valid_types=(Container, SelfMonitoringContainer),
         >>>     )
@@ -919,7 +919,7 @@ class ResourceState(State, Generic[T]):
         if self.name not in instance.__dict__:
             self._set_default(instance)
         obj = instance.__dict__[self.name]
-        if not isinstance(obj, Store | Container):
+        if not issubclass(type(obj), Store | Container):
             raise UpstageError("Bad type of ResourceStatee")
         return cast(T, obj)
 
@@ -941,7 +941,7 @@ class ResourceState(State, Generic[T]):
         if isinstance(copy, Container) and isinstance(new, Container):
             # This is a particularity of simpy containers
             new._level = float(copy.level)
-        return new
+        return cast(T, new)
 
 
 class CommunicationStore(ResourceState[Store]):

--- a/src/upstage/test/test_docs_examples/test_cashier.py
+++ b/src/upstage/test/test_docs_examples/test_cashier.py
@@ -28,7 +28,7 @@ class Cashier(UP.Actor):
         valid_types=(int,),
         recording=True,
     )
-    time_scanning = UP.LinearChangingState[float](
+    time_scanning = UP.LinearChangingState(
         default=0.0,
         valid_types=(float,),
     )

--- a/src/upstage/test/test_docs_examples/test_cashier_complex.py
+++ b/src/upstage/test/test_docs_examples/test_cashier_complex.py
@@ -30,7 +30,7 @@ class Cashier(UP.Actor):
         valid_types=(int,),
         recording=True,
     )
-    time_scanning = UP.LinearChangingState[float](
+    time_scanning = UP.LinearChangingState(
         default=0.0,
         valid_types=(float,),
     )

--- a/src/upstage/test/test_docs_examples/test_nucleus_sharing.py
+++ b/src/upstage/test/test_docs_examples/test_nucleus_sharing.py
@@ -11,7 +11,7 @@ from upstage.type_help import SIMPY_GEN, TASK_GEN
 
 class CPU(UP.Actor):
     n_procs = UP.State[int](default=0, valid_types=int, recording=True)
-    jobs = UP.ResourceState(default=SIM.Store)
+    jobs = UP.ResourceState[SIM.Store](default=SIM.Store)
 
     @staticmethod
     def time_from_data(process_data: dict[str, float]) -> float:

--- a/src/upstage/test/test_docs_examples/test_rehearsing_example.py
+++ b/src/upstage/test/test_docs_examples/test_rehearsing_example.py
@@ -13,7 +13,7 @@ from upstage.utils import waypoint_time_and_dist
 class Plane(UP.Actor):
     speed = UP.State[float]()
     location = UP.CartesianLocationChangingState()
-    fuel = UP.LinearChangingState[float]()
+    fuel = UP.LinearChangingState()
     fuel_burn = UP.State[float]()
 
 

--- a/src/upstage/test/test_integration.py
+++ b/src/upstage/test/test_integration.py
@@ -20,7 +20,7 @@ class ActorForTest(Actor):
 
 
 class StateActor(Actor):
-    fuel = LinearChangingState[float](recording=True)
+    fuel = LinearChangingState(recording=True)
     fuel_burn = State[float](recording=True)
 
 

--- a/src/upstage/test/test_nucleus_state_share/test_refuel_example.py
+++ b/src/upstage/test/test_nucleus_state_share/test_refuel_example.py
@@ -81,7 +81,7 @@ def add_draw(
     time_on: float,
 ) -> SIMPY_GEN:
     class Dummy(UP.Actor):
-        messages = UP.ResourceState(default=SIM.Store)
+        messages = UP.ResourceState[SIM.Store](default=SIM.Store)
 
     d = Dummy(name="a_vehicle")
     yield env.timeout(time_to)

--- a/src/upstage/test/test_state.py
+++ b/src/upstage/test/test_state.py
@@ -41,7 +41,7 @@ class StateTest:
 class StateTestActor(Actor):
     state_one = State[Any]()
     state_two = State[Any](recording=True)
-    state_three = LinearChangingState[float](recording=True)
+    state_three = LinearChangingState(recording=True)
 
 
 def test_state_fails_without_env() -> None:
@@ -148,7 +148,7 @@ def test_linear_changing_state() -> None:
 
 def test_resource_state_valid_types() -> None:
     class Holder(Actor):
-        res = ResourceState(valid_types=Store)
+        res = ResourceState[Store](valid_types=Store)
 
     with EnvironmentContext():
         Holder(
@@ -165,17 +165,17 @@ def test_resource_state_valid_types() -> None:
         with pytest.raises(UpstageError):
 
             class _(Actor):
-                res = ResourceState(valid_types=(1,))  # type: ignore [arg-type]
+                res = ResourceState[Store](valid_types=(1,))  # type: ignore [arg-type]
 
         with pytest.raises(UpstageError):
 
             class _(Actor):  # type: ignore [no-redef]
-                res = ResourceState(valid_types=(Actor,))
+                res = ResourceState[Store](valid_types=(Actor,))
 
 
 def test_resource_state_set_protection() -> None:
     class Holder(Actor):
-        res = ResourceState(valid_types=(Store))
+        res = ResourceState[Store](valid_types=(Store))
 
     with EnvironmentContext():
         h = Holder(
@@ -188,7 +188,7 @@ def test_resource_state_set_protection() -> None:
 
 def test_resource_state_no_default_init() -> None:
     class Holder(Actor):
-        res = ResourceState()
+        res = ResourceState[Store]()
 
     with EnvironmentContext():
         with pytest.raises(UpstageError, match="Missing values for states"):
@@ -211,7 +211,7 @@ def test_resource_state_no_default_init() -> None:
 
 def test_resource_state_default_init() -> None:
     class Holder(Actor):
-        res = ResourceState(default=Store)
+        res = ResourceState[Store](default=Store)
 
     with EnvironmentContext():
         h = Holder(name="Example")
@@ -224,7 +224,7 @@ def test_resource_state_default_init() -> None:
 
 def test_resource_state_kind_init() -> None:
     class Holder(Actor):
-        res = ResourceState()
+        res = ResourceState[Store]()
 
     with EnvironmentContext():
         h = Holder(name="Example", res={"kind": Store, "capacity": 10})

--- a/src/upstage/test/test_state_and_task_sharing.py
+++ b/src/upstage/test/test_state_and_task_sharing.py
@@ -27,7 +27,7 @@ from upstage.type_help import TASK_GEN
 class Mover(Actor):
     location = CartesianLocationChangingState(recording=True)
     speed = State[float](recording=True)
-    fuel = LinearChangingState[float](recording=True)
+    fuel = LinearChangingState(recording=True)
     fuel_burn = State[float](recording=True)
 
     def get_distance(self, waypoints: list[CartesianLocation]) -> float:
@@ -40,7 +40,7 @@ class Mover(Actor):
 class MoverGeo(Actor):
     location = GeodeticLocationChangingState(recording=True)
     speed = State[float](recording=True)
-    fuel = LinearChangingState[float](recording=True)
+    fuel = LinearChangingState(recording=True)
     fuel_burn = State[float](recording=True)
 
     def get_distance(self, waypoints: list[GeodeticLocation]) -> float:

--- a/src/upstage/test/test_state_piggyback.py
+++ b/src/upstage/test/test_state_piggyback.py
@@ -13,12 +13,12 @@ from upstage.type_help import TASK_GEN
 
 
 class Piggy(Actor):
-    a_level = LinearChangingState[float](recording=True)
+    a_level = LinearChangingState(recording=True)
     location = State[str]()
 
 
 class Rider(Actor):
-    b_level = LinearChangingState[float](recording=True)
+    b_level = LinearChangingState(recording=True)
     location = State[str]()
     piggy = State[Piggy]()
 

--- a/src/upstage/test/test_task.py
+++ b/src/upstage/test/test_task.py
@@ -23,7 +23,7 @@ class ActorForTest(Actor):
 
 
 class ActorChangeForTest(Actor):
-    dummy = LinearChangingState[float]()
+    dummy = LinearChangingState()
 
 
 class WorkingTask(Task):
@@ -344,7 +344,7 @@ def test_terminal_task_rehearse(
 class Dummy(Actor):
     status = State[str]()
     rate = State[float]()
-    changer = LinearChangingState[float](recording=True)
+    changer = LinearChangingState(recording=True)
 
 
 class Restartable(Task):

--- a/src/upstage/test/test_task_network.py
+++ b/src/upstage/test/test_task_network.py
@@ -107,7 +107,7 @@ class Aircraft(Actor):
     landing_time = State[float]()
     takeoff_time = State[float]()
     code = State[int]()
-    fuel = LinearChangingState[float](recording=True)
+    fuel = LinearChangingState(recording=True)
     fuel_burn = State[float]()
     parking_token = State[int]()
     parking_spot = State[int]()
@@ -812,7 +812,7 @@ def test_interrupting_network_with_restart() -> None:
 
 def test_rehearsal_time() -> None:
     class Thing(Actor):
-        the_time = LinearChangingState[float](recording=True)
+        the_time = LinearChangingState(recording=True)
 
     class ThingWait(Task):
         def task(self, *, actor: Thing) -> TASK_GEN:


### PR DESCRIPTION
1. __`ResourceStore`__ typing fixes
2. Setting __`LinearChangingState`__ and __`SharedLinearChangingState`__ types to `float` (it's all they will support.
3. Added __`geo_linspace`__ to the __`EarthProtocol`__
4. Updates to test for the changes